### PR TITLE
tunneled rsync: initial impl

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python
 
-from loudds import LoudData,DEFAULT_LOCAL_RSYNCD_BIND_PORT
-louddata = LoudData(access_token="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJvcmlnaW4iOiIqIn0.aTfwJWQP0C6xmdgzydxfAuotpC--8Ls29lU1cdYqwI0")
+import os
+from loudds import LoudData
+import asyncio
 
-tun = louddata.setup_tensorboard_tunnel(dataset_id=1)
-print(tun)
+
+louddata = LoudData(
+    access_token=os.environ["ACCESS_TOKEN"], url="http://cl-backend:8000", dataset_id=1,
+)
+
+tun = louddata.setup_tensorboard_tunnel()
 tun.start()
-print(tun)
 
-input("press something before sending data via rsync...")
-#louddata.download_archive('https://staging-b.louddata.space/assets/f5Isrpkw.tgz', '../data')
+# louddata.download_archive('https://staging-b.louddata.space/assets/f5Isrpkw.tgz', '../data')
 # a tu jest uplaod do tesnorboarda po rsyncu, czyli tu chcemy dodac tunel ssh:
-louddata.upload_tensorboard_logs(louddata.rsyncd_remote_url(DEFAULT_LOCAL_RSYNCD_BIND_PORT))
+louddata.upload_tensorboard_logs(louddata.rsyncd_remote_url())
 
 tun.stop()

--- a/examples/test.py
+++ b/examples/test.py
@@ -2,7 +2,6 @@
 
 import os
 from loudds import LoudData
-import asyncio
 
 
 louddata = LoudData(
@@ -14,6 +13,6 @@ tun.start()
 
 # louddata.download_archive('https://staging-b.louddata.space/assets/f5Isrpkw.tgz', '../data')
 # a tu jest uplaod do tesnorboarda po rsyncu, czyli tu chcemy dodac tunel ssh:
-louddata.upload_tensorboard_logs(louddata.rsyncd_remote_url())
+#louddata.upload_tensorboard_logs(louddata.rsyncd_remote_url())
 
 tun.stop()

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from loudds import LoudData,DEFAULT_LOCAL_RSYNCD_BIND_PORT
+louddata = LoudData(access_token="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJvcmlnaW4iOiIqIn0.aTfwJWQP0C6xmdgzydxfAuotpC--8Ls29lU1cdYqwI0")
+
+tun = louddata.setup_tensorboard_tunnel(dataset_id=1)
+print(tun)
+tun.start()
+print(tun)
+
+input("press something before sending data via rsync...")
+#louddata.download_archive('https://staging-b.louddata.space/assets/f5Isrpkw.tgz', '../data')
+# a tu jest uplaod do tesnorboarda po rsyncu, czyli tu chcemy dodac tunel ssh:
+louddata.upload_tensorboard_logs(louddata.rsyncd_remote_url(DEFAULT_LOCAL_RSYNCD_BIND_PORT))
+
+tun.stop()

--- a/loudds/__init__.py
+++ b/loudds/__init__.py
@@ -6,13 +6,34 @@ import subprocess
 import aiohttp
 import aiofiles
 import asyncio
+import ujson
 from pathlib import Path
 from urllib.parse import urlsplit
+from paramiko.pkey import PKey
+import io
+from contextlib import closing
+
+import paramiko
+import typing
+import sshtunnel
+import logging
 
 LOUDDATA_URL = "http://cl-backend:8000"
+SSH_HOST = 'localhost'
+SSH_USERNAME = 'client'
+SSH_PORT = 30022
+
+LOCAL_SSH_BIND_HOST='localhost'
+
+REMOTE_RSYNCD_PORT = 6873
+DEFAULT_LOCAL_RSYNCD_BIND_PORT = 16873
+KEY_CLASS = paramiko.ecdsakey.ECDSAKey
+
+#TODO: this should be retrieved from backend user connects to via API
+K8S_DOMAIN = 'cluster.local'
 
 
-async def get_url(session, url, dir):
+async def download_url_file(session, url, dir):
     response = await session.get(url)
     if response.status >= 400 and response.status < 500:
         return f"Incorrect url status code: {url} ({response.status})"
@@ -22,15 +43,29 @@ async def get_url(session, url, dir):
     output_filename = parts[-1]
     async with aiofiles.open(dir / output_filename, "wb") as file:
         await file.write(body)
-    await session.close()
+    #await session.close()
     return Path(output_filename)
+
+
+async def download_url(session, url):
+    response = await session.get(url)
+    if response.status >= 400 and response.status < 500:
+        return f"Incorrect url status code: {url} ({response.status})"
+    body = await response.read()
+    return body
 
 
 class LoudData:
     def __init__(self, *, access_token, url=LOUDDATA_URL):
         self.access_token = access_token
         self.url = url
-        self.session = aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar())
+        self.session = aiohttp.ClientSession(
+            cookie_jar=aiohttp.DummyCookieJar(),
+            headers=dict(Authorization=f"Bearer {self.access_token}"),
+        )
+
+        self.setup_ssh_key()
+        self.set_user_data()
 
     def __del__(self):
         loop = asyncio.get_event_loop()
@@ -40,10 +75,40 @@ class LoudData:
 
         loop.run_until_complete(close_session())
 
+
+    def download_ssh_key(self):
+        url = f"{self.url}/api1/ssh/key"
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(download_url(self.session, url))
+
+
+    def set_user_data(self) -> None:
+        url = f"{self.url}/me"
+        loop = asyncio.get_event_loop()
+        raw =  loop.run_until_complete(download_url(self.session, url))
+        parsed = ujson.loads(raw)
+
+        self.client_id = parsed["id"]
+        self.organisation_id = parsed["organisation_id"]
+
+
+    def parse_ssh_key(self, key: str):
+        with closing(io.StringIO(key)) as strio:
+            obj = KEY_CLASS.from_private_key(strio)
+        return obj
+
+    def setup_ssh_key(self):
+        key = self.download_ssh_key()
+        raw = ujson.loads(key.decode("utf-8"))["private_key"]
+        self.ssh_key = self.parse_ssh_key(raw)
+
+
     def download_archive(self, url, dir, flatten=False):
         dir = Path(dir)
         loop = asyncio.get_event_loop()
-        filename = loop.run_until_complete(get_url(self.session, url, Path(dir)))
+        filename = loop.run_until_complete(
+            download_url_file(self.session, url, Path(dir))
+        )
         self.untar_archive(dir / filename, dir, flatten=flatten)
 
     def untar_archive(self, filename, dir, flatten=False):
@@ -80,9 +145,30 @@ class LoudData:
             headers={"Authorization": f"bearer {self.access_token}"},
         )
 
+    def setup_ssh_tunnel(self, local: typing.Tuple[str,str], remote: typing.Tuple[str, str]) -> None:
+        return sshtunnel.open_tunnel(
+            ssh_address_or_host=(SSH_HOST, SSH_PORT),
+            ssh_username=SSH_USERNAME,
+            ssh_pkey=self.ssh_key,
+            local_bind_address=local,
+            remote_bind_address=remote,
+            allow_agent=False,
+            skip_tunnel_checkup=False,
+            debug_level=logging.DEBUG
+        )
+
+    def rsyncd_svc(self, dataset_id):
+        return f"classify-tensorboards-tensorboard-{self.organisation_id}-{dataset_id}-svc.org-{self.organisation_id}.svc.{K8S_DOMAIN}"
+
+    def rsyncd_remote_url(self, rsyncd_port):
+        return f"rsync://{LOCAL_SSH_BIND_HOST}:{rsyncd_port}/runs"
+
+    def setup_tensorboard_tunnel(self, dataset_id, local_rsyncd_port=DEFAULT_LOCAL_RSYNCD_BIND_PORT):
+        return self.setup_ssh_tunnel((LOCAL_SSH_BIND_HOST, local_rsyncd_port),(self.rsyncd_svc(dataset_id), REMOTE_RSYNCD_PORT))
+
     def upload_tensorboard_logs(self, rsync_url, dir="../runs/"):
         return subprocess.run(
-            ["rsync", "-rv", "--inplace", dir, f"rsync://{rsync_url}"],
+            ["rsync", "-rv", "--inplace", dir, rsync_url],
             check=True,
             capture_output=True,
         )

--- a/loudds/__init__.py
+++ b/loudds/__init__.py
@@ -39,7 +39,7 @@ async def download_url_file(client: httpx.AsyncClient, url: str, directory: str)
     return Path(output_filename)
 
 
-async def download_url(client: httpx.AsyncClient, url: str) -> str:
+async def get_url(client: httpx.AsyncClient, url: str) -> str:
     response = await client.get(url)
     if response.status_code != 200:
         raise RuntimeError(f"Incorrect url status code: {url} ({response.status_code})")
@@ -73,11 +73,11 @@ class LoudData:
 
     def download_ssh_key(self) -> str:
         url = f"{self.url}/api1/ssh/key"
-        return trio.run(download_url, self.httpx_client, url)
+        return trio.run(get_url, self.httpx_client, url)
 
     def set_user_data(self) -> None:
         url = f"{self.url}/me"
-        raw = trio.run(download_url, self.httpx_client, url)
+        raw = trio.run(get_url, self.httpx_client, url)
         parsed = ujson.loads(raw)
 
         self.client_id = parsed["id"]
@@ -95,7 +95,7 @@ class LoudData:
 
     def setup_instance_data(self) -> None:
         url = f"{self.url}/api1/info"
-        data = trio.run(download_url, self.httpx_client, url)
+        data = trio.run(get_url, self.httpx_client, url)
         raw = ujson.loads(data.decode("utf-8"))
         self.k8s_domain = raw["k8s_domain"]
         self.proxy_ssh_host = raw["proxy_ssh_host"]

--- a/loudds/__init__.py
+++ b/loudds/__init__.py
@@ -28,23 +28,23 @@ KEY_CLASS = paramiko.ecdsakey.ECDSAKey
 async def download_url_file(client: httpx.AsyncClient, url: str, directory: str) -> str:
     response = await client.get(url)
     if response.status_code >= 400:
-        return f"Incorrect url status code: {url} ({response.status_code})"
+        raise RuntimeError(f"Incorrect url status code: {url} ({response.status_code})")
     body = await response.aread()
     url_parts = urlsplit(url)
     parts = Path(url_parts.path).parts
     output_filename = parts[-1]
     with open(directory / output_filename, "wb") as file:
         file.write(body)
-    response.close()
+    await response.aclose()
     return Path(output_filename)
 
 
 async def download_url(client: httpx.AsyncClient, url: str) -> str:
     response = await client.get(url)
     if response.status_code != 200:
-        return f"Incorrect url status code: {url} ({response.status_code})"
+        raise RuntimeError(f"Incorrect url status code: {url} ({response.status_code})")
     body = await response.aread()
-    response.close()
+    await response.aclose()
     return body
 
 

--- a/loudds/__init__.py
+++ b/loudds/__init__.py
@@ -9,7 +9,6 @@ import asyncio
 import ujson
 from pathlib import Path
 from urllib.parse import urlsplit
-from paramiko.pkey import PKey
 import io
 from contextlib import closing
 
@@ -19,18 +18,12 @@ import sshtunnel
 import logging
 
 LOUDDATA_URL = "http://cl-backend:8000"
-SSH_HOST = 'localhost'
-SSH_USERNAME = 'client'
-SSH_PORT = 30022
-
-LOCAL_SSH_BIND_HOST='localhost'
+SSH_USERNAME = "client"
+LOCAL_SSH_BIND_HOST = "localhost"
 
 REMOTE_RSYNCD_PORT = 6873
 DEFAULT_LOCAL_RSYNCD_BIND_PORT = 16873
 KEY_CLASS = paramiko.ecdsakey.ECDSAKey
-
-#TODO: this should be retrieved from backend user connects to via API
-K8S_DOMAIN = 'cluster.local'
 
 
 async def download_url_file(session, url, dir):
@@ -43,21 +36,26 @@ async def download_url_file(session, url, dir):
     output_filename = parts[-1]
     async with aiofiles.open(dir / output_filename, "wb") as file:
         await file.write(body)
-    #await session.close()
+    # await session.close()
     return Path(output_filename)
 
 
-async def download_url(session, url):
+async def download_url(session: aiohttp.ClientSession, url: str) -> str:
     response = await session.get(url)
-    if response.status >= 400 and response.status < 500:
+    if response.status != 200:
         return f"Incorrect url status code: {url} ({response.status})"
     body = await response.read()
     return body
 
 
 class LoudData:
-    def __init__(self, *, access_token, url=LOUDDATA_URL):
+    def __init__(
+        self, *, access_token: str, url: str = LOUDDATA_URL, dataset_id: int = None, tunnel_bind_host: str = LOCAL_SSH_BIND_HOST
+    ) -> None:
+
+        self.dataset_id = dataset_id
         self.access_token = access_token
+        self.tunnel_bind_host = tunnel_bind_host
         self.url = url
         self.session = aiohttp.ClientSession(
             cookie_jar=aiohttp.DummyCookieJar(),
@@ -65,43 +63,42 @@ class LoudData:
         )
 
         self.setup_ssh_key()
+        self.setup_instance_data()
         self.set_user_data()
 
-    def __del__(self):
-        loop = asyncio.get_event_loop()
 
-        async def close_session():
-            await self.session.close()
-
-        loop.run_until_complete(close_session())
-
-
-    def download_ssh_key(self):
+    def download_ssh_key(self) -> str:
         url = f"{self.url}/api1/ssh/key"
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(download_url(self.session, url))
 
-
     def set_user_data(self) -> None:
         url = f"{self.url}/me"
         loop = asyncio.get_event_loop()
-        raw =  loop.run_until_complete(download_url(self.session, url))
+        raw = loop.run_until_complete(download_url(self.session, url))
         parsed = ujson.loads(raw)
 
         self.client_id = parsed["id"]
         self.organisation_id = parsed["organisation_id"]
 
-
-    def parse_ssh_key(self, key: str):
+    def parse_ssh_key(self, key: str) -> KEY_CLASS:
         with closing(io.StringIO(key)) as strio:
             obj = KEY_CLASS.from_private_key(strio)
         return obj
 
-    def setup_ssh_key(self):
+    def setup_ssh_key(self) -> None:
         key = self.download_ssh_key()
         raw = ujson.loads(key.decode("utf-8"))["private_key"]
         self.ssh_key = self.parse_ssh_key(raw)
 
+    def setup_instance_data(self) -> None:
+        url = f"{self.url}/api1/info"
+        loop = asyncio.get_event_loop()
+        data = loop.run_until_complete(download_url(self.session, url))
+        raw = ujson.loads(data.decode("utf-8"))
+        self.k8s_domain = raw["k8s_domain"]
+        self.proxy_ssh_host = raw["proxy_ssh_host"]
+        self.proxy_ssh_port = raw["proxy_ssh_port"]
 
     def download_archive(self, url, dir, flatten=False):
         dir = Path(dir)
@@ -137,7 +134,10 @@ class LoudData:
                 with open(output, "wb") as out:
                     out.write(data)
 
-    def send_predictions(self, dataset_id, summary):
+    def send_predictions(self, summary, dataset_id=None):
+
+        dataset_id = self._require_value(dataset_id or self.dataset_id)
+
         # TODO: Replace with aiohttp
         return requests.post(
             f"{self.url}/predictions/{dataset_id}",
@@ -145,30 +145,62 @@ class LoudData:
             headers={"Authorization": f"bearer {self.access_token}"},
         )
 
-    def setup_ssh_tunnel(self, local: typing.Tuple[str,str], remote: typing.Tuple[str, str]) -> None:
+    def setup_ssh_tunnel(
+        self, local: typing.Tuple[str, int], remote: typing.Tuple[str, int]
+    ) -> sshtunnel.SSHTunnelForwarder:
         return sshtunnel.open_tunnel(
-            ssh_address_or_host=(SSH_HOST, SSH_PORT),
+            ssh_address_or_host=(self.proxy_ssh_host, self.proxy_ssh_port),
             ssh_username=SSH_USERNAME,
             ssh_pkey=self.ssh_key,
             local_bind_address=local,
             remote_bind_address=remote,
             allow_agent=False,
             skip_tunnel_checkup=False,
-            debug_level=logging.DEBUG
+            debug_level=logging.DEBUG,
         )
 
-    def rsyncd_svc(self, dataset_id):
-        return f"classify-tensorboards-tensorboard-{self.organisation_id}-{dataset_id}-svc.org-{self.organisation_id}.svc.{K8S_DOMAIN}"
+    def rsyncd_svc(self, dataset_id: int) -> str:
+        dataset_id = self._require_value(dataset_id or self.dataset_id)
+        return f"classify-tensorboards-tensorboard-{self.organisation_id}-{dataset_id}-svc.org-{self.organisation_id}.svc.{self.k8s_domain}"
 
-    def rsyncd_remote_url(self, rsyncd_port):
-        return f"rsync://{LOCAL_SSH_BIND_HOST}:{rsyncd_port}/runs"
+    def rsyncd_remote_url(self, rsyncd_port: int = DEFAULT_LOCAL_RSYNCD_BIND_PORT) -> str:
+        return f"rsync://{self.tunnel_bind_host}:{rsyncd_port}/runs"
 
-    def setup_tensorboard_tunnel(self, dataset_id, local_rsyncd_port=DEFAULT_LOCAL_RSYNCD_BIND_PORT):
-        return self.setup_ssh_tunnel((LOCAL_SSH_BIND_HOST, local_rsyncd_port),(self.rsyncd_svc(dataset_id), REMOTE_RSYNCD_PORT))
+    @staticmethod
+    def _require_value(val: typing.Any) -> typing.Any:
+        if val is None:
+            raise ValueError("value is None")
+        return val
 
-    def upload_tensorboard_logs(self, rsync_url, dir="../runs/"):
-        return subprocess.run(
-            ["rsync", "-rv", "--inplace", dir, rsync_url],
-            check=True,
-            capture_output=True,
+    def setup_tensorboard_tunnel(
+        self,
+        local_rsyncd_port: int = DEFAULT_LOCAL_RSYNCD_BIND_PORT,
+        dataset_id: typing.Tuple[None, int] = None,
+    ) -> sshtunnel.SSHTunnelForwarder:
+        dataset_id = self._require_value(dataset_id or self.dataset_id)
+        return self.setup_ssh_tunnel(
+            (self.tunnel_bind_host, local_rsyncd_port),
+            (self.rsyncd_svc(dataset_id), REMOTE_RSYNCD_PORT),
         )
+
+    def upload_tensorboard_logs(
+        self, rsync_url: str, dir: str = "../runs/"
+    ) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                ["rsync", "-rv", "--inplace", dir, rsync_url],
+                check=True,
+                capture_output=True,
+            )
+
+        # default exception handler does not print sdout/stderr from failed process
+        except subprocess.CalledProcessError as e:
+            print("rsync stdout:")
+            print(e.stdout.decode("utf-8"))
+            print("rsync stderr:")
+            print(e.stderr.decode("utf-8"))
+            raise
+
+    async def __aexit__(self, *err):
+        await self.session.close()
+        self.session = None

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Development Status :: 3 - Alpha",
     ],
-    install_requires=["requests", "aiohttp", "aiofiles","sshtunnel","ujson"],
+    install_requires=["requests", "aiohttp", "aiofiles","aiodns","sshtunnel","ujson"],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Development Status :: 3 - Alpha",
     ],
-    install_requires=["requests", "aiohttp", "aiofiles"],
+    install_requires=["requests", "aiohttp", "aiofiles","sshtunnel","ujson"],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Development Status :: 3 - Alpha",
     ],
-    install_requires=["requests", "aiohttp", "aiofiles","aiodns","sshtunnel","ujson"],
+    install_requires=["requests", "sshtunnel", "ujson", "httpx", "trio"],
 )


### PR DESCRIPTION
* added method for setting up ssh tunnels and wrapper for opening rsyncd
  tensorboard tunnels. Multiple tunnels at same time are possible

* added methods for user ssh key retrieval via api

* added methods for user data (especially user id and organisation id
  which are used e.g. for building hostname for rsyncd forwarding)

* added example tunnel setup/teardown. Token is valid for my local pc so
  don't worry too much about it now ;)